### PR TITLE
Refatora mini mapa

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -119,6 +119,7 @@
       </div>
     </div>
   </section>
+  <script src="minimap.js"></script>
   <script src="client.js"></script>
 </body>
 </html>

--- a/public/minimap.js
+++ b/public/minimap.js
@@ -1,0 +1,51 @@
+class MiniMap {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+  }
+
+  render(world, players, apples, drops, myId) {
+    const mtx = this.ctx;
+    if (!mtx) return;
+    const mW = this.canvas.width,
+      mH = this.canvas.height;
+    mtx.clearRect(0, 0, mW, mH);
+    const sx = mW / world.w,
+      sy = mH / world.h;
+
+    mtx.globalAlpha = 0.18;
+    mtx.fillStyle = '#7f8cff';
+    for (let y = 0; y < world.h; y += 4) {
+      for (let x = 0; x < world.w; x += 4) {
+        if (hash32(x, y) > 0.75)
+          mtx.fillRect(
+            Math.floor(x * sx),
+            Math.floor(y * sy),
+            Math.ceil(2 * sx),
+            Math.ceil(2 * sy)
+          );
+      }
+    }
+    mtx.globalAlpha = 1;
+
+    mtx.fillStyle = '#ffcc00';
+    apples.forEach((a) =>
+      mtx.fillRect(a.x * sx, a.y * sy, Math.max(1, sx), Math.max(1, sy))
+    );
+    mtx.fillStyle = '#ff9f1a';
+    drops.forEach((d) =>
+      mtx.fillRect(d.x * sx, d.y * sy, Math.max(1, sx), Math.max(1, sy))
+    );
+    Object.entries(players).forEach(([id, p]) => {
+      mtx.fillStyle = id === myId ? '#ffffff' : '#7c5cff';
+      mtx.fillRect(
+        p.x * sx,
+        p.y * sy,
+        Math.max(1, sx + 0.5),
+        Math.max(1, sy + 0.5)
+      );
+    });
+  }
+}
+
+window.MiniMap = MiniMap;


### PR DESCRIPTION
## Summary
- Extrai e encapsula a lógica do mini‑mapa em um novo módulo `MiniMap`
- Atualiza `client.js` para utilizar a classe `MiniMap` e remove função antiga
- Ajusta `index.html` para carregar o novo script do mini‑mapa

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689776483b04832ca56d9a7a7bbb8386