### PR TITLE
Add login system and ranking screen

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -1,8 +1,9 @@
     function hash32(x, y){ let h=(x*374761393 + y*668265263)|0; h^=h<<13; h^=h>>>17; h^=h<<5; return (h>>>0)/4294967296; }
     function $(id){ return document.getElementById(id); }
-    const screenSetup=$('screen-setup'), screenGame=$('screen-game');
-    const wsUrlEl=$('wsurl'), roomEl=$('room'), nameEl=$('playername'), zoomSel=$('zoom');
-    const btnConnect=$('btnConnect'), btnStart=$('btnStart');
+    const screenSetup=$('screen-setup'), screenRank=$('screen-rank'), screenGame=$('screen-game');
+    const nameEl=$('playername'), zoomSel=$('zoom');
+    const btnStart=$('btnStart'), btnRank=$('btnRank'), backToLogin=$('backToLogin');
+    const rankList=$('rankList');
     const cvs=$('c'), ctx=cvs?cvs.getContext('2d'):null;
     const miniCanvas=$('mini');
     const miniMap=miniCanvas?new MiniMap(miniCanvas):null;
@@ -15,8 +16,8 @@
     let ws, connected=false, running=false, myId=null; let CELL=Number(zoomSel.value);
     let WORLD={w:160,h:120}; let players={}, apples=[], leaderboard=[], drops=[]; let lastServerTick=0;
     const LS_KEY='snake_pro_setup';
-    function loadSetup(){ try{ const s=JSON.parse(localStorage.getItem(LS_KEY)||'{}'); if(s.wsurl) wsUrlEl.value=s.wsurl; if(s.room) roomEl.value=s.room; if(s.name) nameEl.value=s.name; if(s.zoom){ zoomSel.value=String(s.zoom); CELL=Number(s.zoom);} }catch{} }
-    function saveSetup(){ const s={ wsurl:wsUrlEl.value, room:roomEl.value, name:nameEl.value, zoom:Number(zoomSel.value)}; localStorage.setItem(LS_KEY, JSON.stringify(s)); }
+    function loadSetup(){ try{ const s=JSON.parse(localStorage.getItem(LS_KEY)||'{}'); if(s.name) nameEl.value=s.name; if(s.zoom){ zoomSel.value=String(s.zoom); CELL=Number(s.zoom);} }catch{} }
+    function saveSetup(){ const s={ name:nameEl.value, zoom:Number(zoomSel.value)}; localStorage.setItem(LS_KEY, JSON.stringify(s)); }
     const sprites={ groundTile:makeGroundTile(), fruits:makeFruitSprites(), coin:makeCoin() };
     function makeGroundTile(){ const s=24, off=document.createElement('canvas'); off.width=off.height=s; const g=off.getContext('2d'); g.fillStyle='#0f1430'; g.fillRect(0,0,s,s); g.strokeStyle='rgba(255,255,255,0.05)'; g.lineWidth=1; g.beginPath(); g.moveTo(-s,s/2); g.lineTo(s*2,s/2); g.stroke(); g.beginPath(); g.moveTo(0,0); g.lineTo(s,s); g.stroke(); g.beginPath(); g.moveTo(0,s); g.lineTo(s,0); g.stroke(); return off; }
     function makeFruitSprites(){ const types=['apple','banana','cherry','pear']; const map={}; types.forEach(t=> map[t]=drawFruit(t)); return map; function drawFruit(type){ const s=22, off=document.createElement('canvas'); off.width=off.height=s; const g=off.getContext('2d'); if(type==='apple'){ g.fillStyle='#ff3b3b'; g.beginPath(); g.arc(s/2, s/2+1, 8, 0, Math.PI*2); g.fill(); g.fillStyle='rgba(255,255,255,.3)'; g.beginPath(); g.arc(s/2-3, s/2-1, 3, 0, Math.PI*2); g.fill(); g.fillStyle='#6d4c41'; g.fillRect(s/2-1, s/2-10, 2, 5); g.fillStyle='#20e3b2'; g.beginPath(); g.ellipse(s/2+5, s/2-6, 5, 3, -0.6, 0, Math.PI*2); g.fill(); } else if(type==='banana'){ g.strokeStyle='#ffd84d'; g.lineWidth=5; g.beginPath(); g.arc(s/2, s/2+3, 9, 0.2, 2.7); g.stroke(); g.strokeStyle='#e6c43f'; g.lineWidth=2; g.beginPath(); g.arc(s/2, s/2+3, 9, 0.5, 2.4); g.stroke(); } else if(type==='cherry'){ g.fillStyle='#ff4d6d'; g.beginPath(); g.arc(s/2-4, s/2+2, 6, 0, Math.PI*2); g.fill(); g.beginPath(); g.arc(s/2+4, s/2+2, 6, 0, Math.PI*2); g.fill(); g.strokeStyle='#6d4c41'; g.lineWidth=2; g.beginPath(); g.moveTo(s/2-4, s/2-5); g.bezierCurveTo(s/2, s/2-12, s/2, s/2-12, s/2+4, s/2-5); g.stroke(); g.fillStyle='#20e3b2'; g.beginPath(); g.ellipse(s/2, s/2-9, 5, 3, 0, 0, Math.PI*2); g.fill(); } else { g.fillStyle='#7ed957'; g.beginPath(); g.moveTo(s/2, s/2-6); g.bezierCurveTo(s/2+9, s/2-10, s/2+9, s/2+8, s/2, s/2+8); g.bezierCurveTo(s/2-9, s/2+8, s/2-9, s/2-10, s/2, s/2-6); g.fill(); g.fillStyle='#20e3b2'; g.beginPath(); g.ellipse(s/2+4, s/2-8, 5, 3, 0.4, 0, Math.PI*2); g.fill(); g.fillStyle='#6d4c41'; g.fillRect(s/2-1, s/2-12, 2, 5);} return off; } }
@@ -33,25 +34,63 @@
     function sendDir(nx,ny){ if(!connected) return; const now=performance.now(); if(now-lastSend<40) return; if(lastDir&&nx===-lastDir.x&&ny===-lastDir.y) return; lastDir={x:nx,y:ny}; lastSend=now; ws.send(JSON.stringify({type:'dir', x:nx, y:ny})); }
     addEventListener('keydown',(e)=>{ const k=e.key.toLowerCase(); if(k==='escape'){ togglePause(); return; } if(['arrowup','w'].includes(k)) sendDir(0,-1); else if(['arrowdown','s'].includes(k)) sendDir(0,1); else if(['arrowleft','a'].includes(k)) sendDir(-1,0); else if(['arrowright','d'].includes(k)) sendDir(1,0); if(k==='m') miniWrap.classList.toggle('hide'); if(k==='l') leaderWrap.classList.toggle('hide'); if(k==='c') chatWrap.classList.toggle('hide'); });
     if(dpad){ dpad.querySelectorAll('button[data-dir]').forEach(b=> b.addEventListener('click',()=>{ const d=b.dataset.dir; if(d==='up')sendDir(0,-1); if(d==='down')sendDir(0,1); if(d==='left')sendDir(-1,0); if(d==='right')sendDir(1,0); })); }
-    function connect(){ const url=wsUrlEl.value.trim(); ws=new WebSocket(url); const roomInput=(roomEl.value||'').trim().slice(0,24); roomLabel.textContent=roomInput||'auto'; ws.onopen=()=>{ connected=true; btnStart.disabled=false; const hello={type:'hello', name:sanitizeName(nameEl.value)||`Player-${Math.floor(Math.random()*1000)}`}; if(roomInput) hello.room=roomInput; ws.send(JSON.stringify(hello)); ping(); }; ws.onclose=()=>{ connected=false; btnStart.disabled=true; showSetup(); }; ws.onerror=()=>{}; ws.onmessage=(ev)=>{ const data=JSON.parse(ev.data); if(data.type==='init'){ myId=data.id; WORLD=data.world; apples=data.apples; players=data.players; leaderboard=data.leader||[]; lastServerTick=data.tick||0; drops=data.drops||[]; roomLabel.textContent=data.room||roomInput||'auto'; updateHUD(); resizeToViewport(); renderLeader(); } else if(data.type==='state'){ apples=data.apples; players=data.players; leaderboard=data.leader||[]; drops=data.drops||[]; lastServerTick=data.tick||0; updateHUD(); renderLeader(); } else if(data.type==='chat'){ pushChat(data.text); } else if(data.type==='msg'){ pushChat(data.text); } else if(data.type==='pong'){ pingEl.textContent=Math.round(performance.now()-data.t); } }; }
+    function connect(){
+      const protocol = location.protocol === 'https:' ? 'wss://' : 'ws://';
+      const url = protocol + location.host;
+      ws = new WebSocket(url);
+      roomLabel.textContent='auto';
+      ws.onopen = () => {
+        connected = true;
+        const hello = { type:'hello', name:sanitizeName(nameEl.value)||`Player-${Math.floor(Math.random()*1000)}` };
+        ws.send(JSON.stringify(hello));
+        ping();
+      };
+      ws.onclose = () => { connected=false; running=false; btnStart.disabled=false; showLogin(); };
+      ws.onerror = () => {};
+      ws.onmessage = (ev) => {
+        const data = JSON.parse(ev.data);
+        if(data.type==='init'){
+          myId=data.id; WORLD=data.world; apples=data.apples; players=data.players; leaderboard=data.leader||[]; lastServerTick=data.tick||0; drops=data.drops||[];
+          roomLabel.textContent=data.room||'auto';
+          updateHUD(); resizeToViewport(); renderLeader();
+          showGame(); running=true; ws.send(JSON.stringify({type:'start'}));
+        } else if(data.type==='state'){
+          apples=data.apples; players=data.players; leaderboard=data.leader||[]; drops=data.drops||[]; lastServerTick=data.tick||0; updateHUD(); renderLeader();
+        } else if(data.type==='chat'){
+          pushChat(data.text);
+        } else if(data.type==='msg'){
+          pushChat(data.text);
+        } else if(data.type==='pong'){
+          pingEl.textContent=Math.round(performance.now()-data.t);
+        }
+      };
+    }
     function sanitizeName(n){ return String(n||'').replace(/[^\p{L}\p{N}_\- ]/gu,'').trim().slice(0,18); }
     function updateHUD(){ pcountEl.textContent=Object.keys(players).length; const me=players[myId]; scoreEl.textContent=me?me.score:0; worldEl.textContent=`${WORLD.w}x${WORLD.h}`; }
     function renderLeader(){ leaderEl.innerHTML=''; leaderboard.slice(0,10).forEach(it=>{ const li=document.createElement('li'); li.textContent=`${it.name} — ${it.score}`; leaderEl.appendChild(li); }); }
+    function fetchRank(){
+      fetch('/rank').then(r=>r.json()).then(list=>{
+        rankList.innerHTML='';
+        list.forEach(it=>{ const li=document.createElement('li'); li.textContent=`${it.name} — ${it.score}`; rankList.appendChild(li); });
+      }).catch(()=>{ rankList.innerHTML='<li>erro ao carregar</li>'; });
+    }
     function pushChat(t){ const d=document.createElement('div'); d.textContent=t; chatlog.appendChild(d); chatlog.scrollTop=chatlog.scrollHeight; }
     function ping(){ if(!connected) return; ws.send(JSON.stringify({type:'ping', t: performance.now()})); setTimeout(ping,1000); }
     function resizeToViewport(){ const w=innerWidth, h=innerHeight; if(cvs){ cvs.width=w; cvs.height=h; } if(miniCanvas){ miniCanvas.width=220; miniCanvas.height=220; } }
     addEventListener('resize', resizeToViewport);
-    function showGame(){ screenSetup.style.display='none'; screenGame.style.display='block'; resizeToViewport(); }
-    function showSetup(){ screenSetup.style.display='grid'; screenGame.style.display='none'; }
+    function showGame(){ screenSetup.style.display='none'; screenRank.style.display='none'; screenGame.style.display='block'; resizeToViewport(); }
+    function showLogin(){ screenSetup.style.display='grid'; screenRank.style.display='none'; screenGame.style.display='none'; }
+    function showRank(){ screenSetup.style.display='none'; screenGame.style.display='none'; screenRank.style.display='grid'; }
     function togglePause(){ const vis=pause.classList.contains('hide'); if(vis){ pause.classList.remove('hide'); running=false; ws?.send(JSON.stringify({type:'pause'})); } else { pause.classList.add('hide'); running=true; ws?.send(JSON.stringify({type:'resume'})); } }
     $('resume').onclick=()=>togglePause();
-    $('backToSetup').onclick=()=>{ ws?.close(); showSetup(); };
-    $('disconnect').onclick=()=>{ ws?.close(); showSetup(); };
-    $('btnConnect').onclick=()=>{ saveSetup(); connect(); $('btnConnect').disabled=true; };
-    $('btnStart').onclick=()=>{ if(!connected) return; showGame(); running=true; ws.send(JSON.stringify({type:'start'})); };
+    $('backToSetup').onclick=()=>{ ws?.close(); showLogin(); };
+    $('disconnect').onclick=()=>{ ws?.close(); showLogin(); };
+    btnStart.onclick=()=>{ saveSetup(); btnStart.disabled=true; connect(); };
+    btnRank.onclick=()=>{ fetchRank(); showRank(); };
+    backToLogin.onclick=()=>{ showLogin(); };
     zoomSel.addEventListener('change',()=>{ CELL=Number(zoomSel.value); saveSetup(); resizeToViewport(); });
     toggleMini.onclick=()=> miniWrap.classList.toggle('hide');
     toggleLeader.onclick=()=> leaderWrap.classList.toggle('hide');
     toggleChat.onclick=()=> chatWrap.classList.toggle('hide');
     loadSetup();
-    showSetup();
+    showLogin();

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     :root{ --ink:#e8ecff; --muted:#aab3ff; --accent:#7c5cff; }
     html,body{height:100%;margin:0}
     body{background:#0b1020;color:var(--ink);font-family:system-ui,Arial}
-    #screen-setup{position:fixed;inset:0;display:grid;place-items:center;background:radial-gradient(1200px 600px at 50% -10%, #1a2045 0%, #0b1020 60%);} 
+    #screen-setup,#screen-rank{position:fixed;inset:0;display:grid;place-items:center;background:radial-gradient(1200px 600px at 50% -10%, #1a2045 0%, #0b1020 60%);}
     .setup-card{width:min(900px,92vw);padding:24px;border:1px solid #2f3568;border-radius:16px;background:rgba(18,21,52,.55);backdrop-filter: blur(6px);} 
     .setup-title{display:flex;align-items:center;gap:10px;font-size:28px;font-weight:800;margin:0 0 16px}
     .setup-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
@@ -44,19 +44,11 @@
   </style>
 </head>
 <body>
-  <section id="screen-setup" aria-label="Configuração">
+  <section id="screen-setup" aria-label="Login">
     <div class="setup-card">
       <h1 class="setup-title">🐍 Snake — PRO Multiplayer</h1>
       <div class="setup-grid">
-        <div>
-          <label>Servidor WS</label>
-          <input id="wsurl" value="ws://localhost:8080" />
-        </div>
-        <div>
-          <label>Sala (deixe em branco para automática)</label>
-          <input id="room" placeholder="automática" />
-        </div>
-        <div>
+        <div class="full">
           <label>Seu nome</label>
           <input id="playername" placeholder="Jogador" />
         </div>
@@ -72,8 +64,17 @@
         <div class="full hint">Dica: você pode reabrir esta tela a qualquer momento com <b>Esc</b>.</div>
       </div>
       <div class="setup-actions">
-        <button id="btnConnect">Conectar</button>
-        <button id="btnStart" disabled>Entrar no jogo</button>
+        <button id="btnRank">Ranking</button>
+        <button id="btnStart">Entrar no jogo</button>
+      </div>
+    </div>
+  </section>
+  <section id="screen-rank" aria-label="Ranking" style="display:none">
+    <div class="setup-card">
+      <h1 class="setup-title">🏆 Ranking</h1>
+      <ol id="rankList"></ol>
+      <div class="setup-actions">
+        <button id="backToLogin">Voltar</button>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add login screen for player name and in-game entry
- expose ranking endpoint and global scoring
- implement ranking view with automatic room selection on connect

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68977a390660832c92089ef37f3b41ca