### PR TITLE
Fix minimap background covering mini map

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     .hint{color:#9bb;font-size:12px;margin-top:6px}
     #screen-game{position:fixed;inset:0;display:none;background:#0b1020}
     #game{position:absolute;inset:0}
-    #game canvas{position:absolute;inset:0;width:100vw;height:100vh;display:block;background:#0f0f17}
+    #game > canvas{position:absolute;inset:0;width:100vw;height:100vh;display:block;background:#0f0f17}
     .overlay{position:absolute;z-index:10;color:var(--ink);font-size:12px}
     .hud-top{top:8px;left:12px;right:12px;display:flex;gap:8px;align-items:center;pointer-events:none}
     .pill{padding:6px 10px;border-radius:999px;background:rgba(20,24,55,.35);backdrop-filter: blur(4px);border:1px solid rgba(127,140,255,.25); pointer-events:auto}


### PR DESCRIPTION
## Summary
- Prevent global canvas styles from forcing a dark background on the mini‑map

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897c9927f70832cb66af30438930c08