### PR TITLE
feat: enable client chat input

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -92,5 +92,13 @@
     toggleMini.onclick=()=> miniWrap.classList.toggle('hide');
     toggleLeader.onclick=()=> leaderWrap.classList.toggle('hide');
     toggleChat.onclick=()=> chatWrap.classList.toggle('hide');
+    chatInput.addEventListener('keydown',e=>{
+      e.stopPropagation();
+      if(e.key==='Enter'){
+        const text=chatInput.value.trim();
+        if(text&&connected){ ws?.send(JSON.stringify({type:'chat', text})); }
+        chatInput.value='';
+      }
+    });
     loadSetup();
     showLogin();


### PR DESCRIPTION
## Summary
- allow players to send chat messages by pressing Enter
- prevent game controls while typing in chat

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897c9e94810832ca5bd84b29066cc08