### PR TITLE
feat: add level system and decorative rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ PORT=3000 npm start
 ## Novidades
 - Mapa expandido para 160x120 células.
 - Sistema de salas automático que agrupa até 50 jogadores por sala. Deixe o campo **Sala** vazio para entrar automaticamente.
+- Sistema de níveis que envia mensagens de progresso ao subir de nível.
+- Terreno com elementos decorativos como árvores e pedras para um visual mais rico.

--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,7 @@
       </div>
       <div class="overlay hud-top" id="hud">
         <span class="pill">Pontos: <b id="score">0</b></span>
+        <span class="pill">Nível: <b id="level">1</b></span>
         <span class="pill">Jogadores: <b id="pcount">0</b></span>
         <span class="pill">Ping: <b id="ping">--</b> ms</span>
         <span class="pill">Mundo: <b id="world">--</b></span>


### PR DESCRIPTION
## Summary
- add level display and chat notification when leveling up
- enrich ground visuals with rock sprites alongside trees
- document new level system and terrain improvements

## Testing
- `node --check public/client.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897cfb1f94c832cb0b8811f9681a470