### PR TITLE
Add PDF utilities module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,22 @@ PORT=3000 npm start
 - Sistema de salas automático que agrupa até 50 jogadores por sala. Deixe o campo **Sala** vazio para entrar automaticamente.
 - Sistema de níveis que envia mensagens de progresso ao subir de nível.
 - Terreno com elementos decorativos como árvores e pedras para um visual mais rico.
+
+## PDF Utilities
+
+Este projeto inclui agora um módulo simples para manipulação de PDFs localizado em `pdf-tools.js`.
+
+### Funções Disponíveis
+- **mergePDFs**: une vários arquivos PDF em um único.
+- **extractText**: extrai o texto de um arquivo PDF.
+
+### Exemplo de Uso
+```javascript
+const { mergePDFs, extractText } = require('./pdf-tools');
+
+(async () => {
+  await mergePDFs(['a.pdf', 'b.pdf'], 'merged.pdf');
+  const text = await extractText('merged.pdf');
+  console.log(text);
+})();
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,43 @@
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.5",
+        "pdf-lib": "^1.17.1",
+        "pdf-parse": "^1.1.1",
         "ws": "^8.18.3"
       }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "5.1.5",
@@ -30,6 +65,49 @@
       "engines": {
         "node": "^18 || >=20"
       }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "description": "",
   "dependencies": {
     "nanoid": "^5.1.5",
+    "pdf-lib": "^1.17.1",
+    "pdf-parse": "^1.1.1",
     "ws": "^8.18.3"
   }
 }

--- a/pdf-tools.js
+++ b/pdf-tools.js
@@ -1,0 +1,40 @@
+const fs = require('fs').promises;
+const { PDFDocument } = require('pdf-lib');
+const pdfParse = require('pdf-parse');
+
+/**
+ * Merge multiple PDF files into a single PDF.
+ * @param {string[]} inputPaths - Paths to PDF files.
+ * @param {string} [outputPath] - Optional path to save the merged PDF.
+ * @returns {Promise<Uint8Array>} The merged PDF bytes.
+ */
+async function mergePDFs(inputPaths, outputPath) {
+  const mergedPdf = await PDFDocument.create();
+  for (const p of inputPaths) {
+    const bytes = await fs.readFile(p);
+    const pdf = await PDFDocument.load(bytes);
+    const copiedPages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
+    copiedPages.forEach(page => mergedPdf.addPage(page));
+  }
+  const mergedBytes = await mergedPdf.save();
+  if (outputPath) {
+    await fs.writeFile(outputPath, mergedBytes);
+  }
+  return mergedBytes;
+}
+
+/**
+ * Extract text content from a PDF file.
+ * @param {string|Buffer} file - Path or buffer of the PDF to parse.
+ * @returns {Promise<string>} Extracted text.
+ */
+async function extractText(file) {
+  const data = Buffer.isBuffer(file) ? file : await fs.readFile(file);
+  const result = await pdfParse(data);
+  return result.text;
+}
+
+module.exports = {
+  mergePDFs,
+  extractText,
+};


### PR DESCRIPTION
## Summary
- add `pdf-tools.js` with functions to merge PDFs and extract text
- document PDF utilities in README
- include `pdf-lib` and `pdf-parse` dependencies

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "require('./pdf-tools'); console.log('pdf tools loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_689b55054804832c980e1eef9383999c